### PR TITLE
[stable/spinnaker] set appVersion to the spinnaker's version it's going to deploy

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.6
-appVersion: 1.16.2
+version: 2.2.7
+appVersion: 1.19.4
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/charts/spinnaker/README.md
+++ b/charts/spinnaker/README.md
@@ -64,7 +64,7 @@ Open source, multi-cloud continuous delivery platform for releasing software cha
 | halyard.persistence.enabled | bool | `true` |  |
 | halyard.resources | object | `{}` |  |
 | halyard.serviceConfigs | object | `{}` |  |
-| halyard.spinnakerVersion | string | `"1.19.4"` |  |
+| halyard.spinnakerVersion | string | `nil` |  |
 | ingress.enabled | bool | `false` |  |
 | ingressGate.enabled | bool | `false` |  |
 | kubeConfig.checkPermissionsOnStartup | bool | `true` |  |

--- a/charts/spinnaker/templates/configmap/bom.yaml
+++ b/charts/spinnaker/templates/configmap/bom.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 data:
-  {{ .Values.halyard.spinnakerVersion }}.yml:
+  {{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}.yml:
   {{ .Values.halyard.bom | toYaml | indent 4 }}
 {{- end }}

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -35,9 +35,9 @@ data:
   config.sh: |
     # Spinnaker version
     {{ if .Values.halyard.bom }}
-    $HAL_COMMAND config version edit --version local:{{ .Values.halyard.spinnakerVersion }}
+    $HAL_COMMAND config version edit --version local:{{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}
     {{ else }}
-    $HAL_COMMAND config version edit --version {{ .Values.halyard.spinnakerVersion }}
+    $HAL_COMMAND config version edit --version {{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}
     {{ end }}
 
     # Storage

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -1,5 +1,5 @@
 halyard:
-  spinnakerVersion: 1.19.4
+  # spinnakerVersion: 1.19.4
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
     tag: 1.32.0


### PR DESCRIPTION
#### What this PR does / why we need it:

I feel that the current appVersion is misleading since it looks like it is going to deploy an outdated Spinnaker. By using the AppVersion as the spinnaker version just by updating this value the helm chart is going to be updated to another version making the halyard.spinnakerVersion optional

#### Special notes for your reviewer:

By using .Chart.AppVersion simplifies the version upgrade of this helm chart yet still giving the user the ability to set another version by defining halyard.spinnakerVersion which is no longer a required setting

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
